### PR TITLE
reaper, admin views and actions, uuid rooms

### DIFF
--- a/reddit_robin/__init__.py
+++ b/reddit_robin/__init__.py
@@ -57,13 +57,23 @@ class Robin(Plugin):
             conditions={"function": not_in_sr})
         mc("/robin/all", controller="robin", action="all",
             conditions={"function": not_in_sr})
+        mc("/robin/admin", controller="robin", action="admin",
+            conditions={"function": not_in_sr})
         mc("/robin/join", controller="robin", action="join",
+            conditions={"function": not_in_sr})
+        mc("/robin/:room_id", controller="robin", action="force_room",
+            conditions={"function": not_in_sr})
+        mc("/robin/user/:user", controller="robin", action="user_room",
             conditions={"function": not_in_sr})
         mc("/api/robin/:room_id/:action", controller="robin",
             conditions={"function": not_in_sr})
         mc("/api/join_room", controller="robin", action="join_room",
             conditions={"function": not_in_sr})
         mc("/api/room_assignment", controller="robin", action="room_assignment",
+            conditions={"function": not_in_sr})
+        mc("/api/admin_prompt", controller="robin", action="admin_prompt",
+            conditions={"function": not_in_sr})
+        mc("/api/admin_reap", controller="robin", action="admin_reap",
             conditions={"function": not_in_sr})
 
     def load_controllers(self):

--- a/reddit_robin/__init__.py
+++ b/reddit_robin/__init__.py
@@ -53,11 +53,11 @@ class Robin(Plugin):
         )
 
     def add_routes(self, mc):
-        mc("/robin", controller="robin", action="home",
+        mc("/robin", controller="robin", action="chat",
             conditions={"function": not_in_sr})
         mc("/robin/all", controller="robin", action="all",
             conditions={"function": not_in_sr})
-        mc("/robin/:room_id", controller="robin", action="chat",
+        mc("/robin/join", controller="robin", action="join",
             conditions={"function": not_in_sr})
         mc("/api/robin/:room_id/:action", controller="robin",
             conditions={"function": not_in_sr})

--- a/reddit_robin/controllers.py
+++ b/reddit_robin/controllers.py
@@ -23,7 +23,7 @@ from .pages import (
     RobinAll,
     RobinPage,
     RobinChatPage,
-    RobinHome,
+    RobinJoin,
     RobinChat,
 )
 from .models import RobinRoom
@@ -35,15 +35,14 @@ class RobinController(RedditController):
     @validate(
         VUser(),
     )
-    def GET_home(self):
+    def GET_join(self):
         room = RobinRoom.get_room_for_user(c.user)
         if room:
-            self.redirect("/robin/{room_id}".format(room_id=room.id))
-            return
+            return self.redirect("/robin")
 
         return RobinPage(
             title="robin",
-            content=RobinHome(),
+            content=RobinJoin(),
         ).render()
 
     @validate(
@@ -58,12 +57,14 @@ class RobinController(RedditController):
             content=RobinAll(),
         ).render()
 
-
     @validate(
         VUser(),
-        room=VRobinRoom("room_id"),
     )
-    def GET_chat(self, room):
+    def GET_chat(self):
+        room = RobinRoom.get_room_for_user(c.user)
+        if not room:
+            return self.redirect("/robin/join")
+
         path = posixpath.join("/robin", room.id, c.user._id36)
         websocket_url = websockets.make_url(path, max_age=3600)
 

--- a/reddit_robin/controllers.py
+++ b/reddit_robin/controllers.py
@@ -38,7 +38,7 @@ class RobinController(RedditController):
     def GET_home(self):
         room = RobinRoom.get_room_for_user(c.user)
         if room:
-            self.redirect("/robin/{room_id}".format(room_id=room._id))
+            self.redirect("/robin/{room_id}".format(room_id=room.id))
             return
 
         return RobinPage(
@@ -64,7 +64,7 @@ class RobinController(RedditController):
         room=VRobinRoom("room_id"),
     )
     def GET_chat(self, room):
-        path = posixpath.join("/robin", str(room._id), c.user._id36)
+        path = posixpath.join("/robin", room.id, c.user._id36)
         websocket_url = websockets.make_url(path, max_age=3600)
 
         all_user_ids = room.get_all_participants()
@@ -88,10 +88,11 @@ class RobinController(RedditController):
             });
 
         return RobinChatPage(
-            title="chat in %s" % room._id,
+            title="chat in %s" % room.name,
             content=RobinChat(room=room),
             extra_js_config={
-                "robin_room_id": room._id,
+                "robin_room_name": room.name,
+                "robin_room_id": room.id,
                 "robin_websocket_url": websocket_url,
                 "robin_user_list": user_list,
             },
@@ -111,7 +112,7 @@ class RobinController(RedditController):
         # if we decide we want logging, perhaps we can make a logger that
         # watches the amqp bus instead of complicating this request logic?
         websockets.send_broadcast(
-            namespace="/robin/" + room._id,
+            namespace="/robin/" + room.id,
             type="chat",
             payload={
                 "from": c.user.name,
@@ -138,7 +139,7 @@ class RobinController(RedditController):
             return
 
         websockets.send_broadcast(
-            namespace="/robin/" + room._id,
+            namespace="/robin/" + room.id,
             type="vote",
             payload={
                 "from": c.user.name,
@@ -164,4 +165,4 @@ class RobinController(RedditController):
     def GET_room_assignment(self, responder):
         room = RobinRoom.get_room_for_user(c.user)
         if room:
-            return {"roomId": room._id}
+            return {"roomId": room.id}

--- a/reddit_robin/matchmaker.py
+++ b/reddit_robin/matchmaker.py
@@ -3,6 +3,7 @@ import random
 from pylons import app_globals as g
 
 from r2.lib import amqp
+from r2.lib import websockets
 from r2.models import Account
 
 from .models import RobinRoom
@@ -40,6 +41,13 @@ def run_waitinglist():
 
             if current_room_id:
                 g.cache.delete("current_robin_room")
+                websockets.send_broadcast(
+                    namespace="/robin/" + current_room.id,
+                    type="updated_name",
+                    payload={
+                        "room_name": current_room.name,
+                    },
+                )
             else:
                 g.cache.set("current_robin_room", current_room.id)
 

--- a/reddit_robin/matchmaker.py
+++ b/reddit_robin/matchmaker.py
@@ -8,33 +8,10 @@ from r2.models import Account
 from .models import RobinRoom
 
 
-def make_room_name_list():
-    try:
-        with open("/usr/share/dict/words", "r") as f:
-            # `apt-get install wamerican` if you don't have this file
-            words = f.readlines()
-    except IOError:
-        # poor man's word list
-        import random
-        letters = "abcdefghijklmnopqrstuvwxyz"
-        words = [
-            "".join(random.sample(letters, 8)) for i in xrange(1000)
-        ]
-
-    words = map(lambda word: word.strip().lower(), words)
-    words = filter(lambda word: len(word) > 6, words)
-    words = filter(lambda word: all(c.isalpha() for c in word), words)
-    return words
-
-
-ROOM_NAMES = make_room_name_list()
-
-
 def make_new_room():
     while True:
-        name = random.choice(ROOM_NAMES)
         try:
-            room = RobinRoom.create(name, level=0)
+            room = RobinRoom.create(level=0)
         except ValueError:
             continue
         else:
@@ -52,19 +29,19 @@ def run_waitinglist():
             return
 
         with g.make_lock("robin_room", "global"):
-            current_room_name = g.cache.get("current_robin_room")
-            if not current_room_name:
+            current_room_id = g.cache.get("current_robin_room")
+            if not current_room_id:
                 current_room = make_new_room()
             else:
-                current_room = RobinRoom._byID(current_room_name)
+                current_room = RobinRoom._byID(current_room_id)
 
             current_room.add_participants([user])
-            print "added %s to %s" % (user.name, current_room._id)
+            print "added %s to %s" % (user.name, current_room.id)
 
-            if current_room_name:
+            if current_room_id:
                 g.cache.delete("current_robin_room")
             else:
-                g.cache.set("current_robin_room", current_room._id)
+                g.cache.set("current_robin_room", current_room.id)
 
     amqp.consume_items("robin_waitinglist_q", process_waitinglist)
 

--- a/reddit_robin/matchmaker.py
+++ b/reddit_robin/matchmaker.py
@@ -4,6 +4,7 @@ from pylons import app_globals as g
 
 from r2.lib import amqp
 from r2.lib import websockets
+from r2.lib.db import tdb_cassandra
 from r2.models import Account
 
 from .models import RobinRoom
@@ -34,7 +35,11 @@ def run_waitinglist():
             if not current_room_id:
                 current_room = make_new_room()
             else:
-                current_room = RobinRoom._byID(current_room_id)
+                try:
+                    current_room = RobinRoom._byID(current_room_id)
+                except tdb_cassandra.NotFoundException:
+                    current_room_id = None
+                    current_room = make_new_room()
 
             current_room.add_participants([user])
             print "added %s to %s" % (user.name, current_room.id)

--- a/reddit_robin/models.py
+++ b/reddit_robin/models.py
@@ -158,6 +158,7 @@ class ParticipantVoteByRoom(tdb_cassandra.View):
     of users that belong to a room."""
     _use_db = True
     _connection_pool = 'main'
+    _fetch_all_columns = True
     _extra_schema_creation_args = dict(
         key_validation_class=tdb_cassandra.TIME_UUID_TYPE,
     )
@@ -226,6 +227,7 @@ class ParticipantVoteByRoom(tdb_cassandra.View):
 class ParticipantPresenceByRoom(tdb_cassandra.View):
     _use_db = True
     _connection_pool = 'main'
+    _fetch_all_columns = True
     _extra_schema_creation_args = dict(
         key_validation_class=tdb_cassandra.TIME_UUID_TYPE,
     )

--- a/reddit_robin/pages.py
+++ b/reddit_robin/pages.py
@@ -2,6 +2,7 @@ from pylons import tmpl_context as c
 
 from r2.lib.pages import Reddit
 from r2.lib.wrapped import Templated
+from r2.models import Account
 
 from reddit_robin.models import RobinRoom
 
@@ -33,10 +34,17 @@ class RobinJoin(Templated):
 class RobinAll(Templated):
     def __init__(self):
         all_rooms = list(RobinRoom.generate_alive_rooms())
-        self.all_rooms = [room.id for room in all_rooms]
-        self.user_rooms = [
-            room.id for room in all_rooms if room.is_participant(c.user)]
+        self.participants_by_room = {}
+        for room in all_rooms:
+            participant_ids = room.get_all_participants()
+            participants = Account._byID(
+                participant_ids, data=True, return_dict=False)
+            self.participants_by_room[room.id] = participants
         Templated.__init__(self)
+
+
+class RobinAdmin(Templated):
+    pass
 
 
 class RobinChat(Templated):

--- a/reddit_robin/pages.py
+++ b/reddit_robin/pages.py
@@ -33,9 +33,9 @@ class RobinHome(Templated):
 class RobinAll(Templated):
     def __init__(self):
         all_rooms = list(RobinRoom.generate_all_rooms())
-        self.all_rooms = [room._id for room in all_rooms]
+        self.all_rooms = [room.id for room in all_rooms]
         self.user_rooms = [
-            room._id for room in all_rooms if room.is_participant(c.user)]
+            room.id for room in all_rooms if room.is_participant(c.user)]
         Templated.__init__(self)
 
 

--- a/reddit_robin/pages.py
+++ b/reddit_robin/pages.py
@@ -32,7 +32,7 @@ class RobinJoin(Templated):
 
 class RobinAll(Templated):
     def __init__(self):
-        all_rooms = list(RobinRoom.generate_all_rooms())
+        all_rooms = list(RobinRoom.generate_alive_rooms())
         self.all_rooms = [room.id for room in all_rooms]
         self.user_rooms = [
             room.id for room in all_rooms if room.is_participant(c.user)]

--- a/reddit_robin/pages.py
+++ b/reddit_robin/pages.py
@@ -26,7 +26,7 @@ class RobinChatPage(RobinPage):
     pass
 
 
-class RobinHome(Templated):
+class RobinJoin(Templated):
     pass
 
 

--- a/reddit_robin/presence.py
+++ b/reddit_robin/presence.py
@@ -4,6 +4,7 @@ import posixpath
 from pylons import app_globals as g
 
 from r2.lib import amqp, websockets
+from r2.lib.db import tdb_cassandra
 from r2.models import Account
 
 from .models import ParticipantPresenceByRoom, RobinRoom
@@ -22,7 +23,10 @@ def run():
         room_namespace = posixpath.dirname(namespace)
 
         account = Account._byID36(user_id36, data=True)
-        room = RobinRoom._byID(room_namespace)
+        try:
+            room = RobinRoom._byID(room_namespace)
+        except tdb_cassandra.NotFoundException:
+            return
 
         if not room.is_participant(account):
             return

--- a/reddit_robin/public/static/js/robin/init.js
+++ b/reddit_robin/public/static/js/robin/init.js
@@ -138,6 +138,7 @@
       // initialize some models for managing state
       this.room = new models.RobinRoom({
         room_id: this.options.room_id,
+        room_name: this.options.room_name,
       });
 
       this.systemUser = new models.RobinUser({
@@ -284,6 +285,7 @@
   $(function() {
     new RobinChat({
       el: document.getElementById('robinChat'),
+      room_name: r.config.robin_room_name,
       room_id: r.config.robin_room_id,
       websocket_url: r.config.robin_websocket_url,
       participants: r.config.robin_user_list,

--- a/reddit_robin/public/static/js/robin/init.js
+++ b/reddit_robin/public/static/js/robin/init.js
@@ -37,6 +37,29 @@
       'message:part': function(message) {
         this.addSystemMessage(message.user + ' has left the room');
       },
+
+      'message:please_vote': function(message) {
+        this.addSystemMessage('polls are closing soon, please vote');
+      },
+
+      'message:merge': function(message) {
+        this.addSystemMessage('merging with other room...');
+        // TODO: add some jitter before refresh to avoid thundering herd
+        $.refresh()
+      },
+
+      'message:abandon': function(message) {
+        this.addSystemMessage('room has been abandoned');
+      },
+
+      'message:continue': function(message) {
+        this.addSystemMessage('room has been continued');
+      },
+
+      'message:no_match': function(message) {
+        this.addSystemMessage('no compatible room found for matching');
+      },
+
     },
 
     roomEvents: {

--- a/reddit_robin/public/static/js/robin/models.js
+++ b/reddit_robin/public/static/js/robin/models.js
@@ -121,6 +121,7 @@
 
     defaults: {
       room_id: null,
+      room_name: null,
       api_type: 'json',
     },
 

--- a/reddit_robin/reaper.py
+++ b/reddit_robin/reaper.py
@@ -1,0 +1,123 @@
+from datetime import datetime, timedelta
+
+from pylons import app_globals as g
+
+from r2.lib import websockets
+from .models import RobinRoom
+
+
+"""
+reaping happens every 15 minutes
+5 minutes before the reaping we will prompt each room to vote
+
+doing it on a fixed schedule like this will put all rooms in sync rather than
+having them age in reference from their creation date. this simplifies the merging.
+
+Update your cron (for local installs):
+/etc/cron.d/reddit
+*/15 * * * * root /sbin/start --quiet reddit-job-robin_reap_ripe_rooms
+10-59/15 * * * * root /sbin/start --quiet reddit-job-robin_prompt_for_voting
+
+
+"""
+
+
+def prompt_for_voting(room_age_minutes=6):
+    now = datetime.now(g.tz)
+    alert_older_than = now - timedelta(minutes=room_age_minutes)
+    print "%s: prompting rooms older than %s" % (now, alert_older_than)
+
+    count = 0
+    for room in RobinRoom.generate_rooms_for_prompting(cutoff=alert_older_than):
+        count += 1
+        websockets.send_broadcast(
+            namespace="/robin/" + room.id,
+            type="please_vote",
+            payload={},
+        )
+        room.mark_prompted()
+        print "prompted %s" % room
+    print "%s: done prompting (%s rooms took %s)" % (datetime.now(g.tz), count, datetime.now(g.tz) - now)
+
+
+def reap_ripe_rooms(room_age_minutes=10):
+    # reap rooms older than 10 minutes, and the reaper job runs every 15 minutes
+    # this offset accounts for the time it takes to run reaping
+    now = datetime.now(g.tz)
+    reap_older_than = now - timedelta(minutes=room_age_minutes)
+    print "%s: reaping rooms older than %s" % (now, reap_older_than)
+
+    to_merge_by_level = {}
+    count = 0
+    for room in RobinRoom.generate_rooms_for_reaping(cutoff=reap_older_than):
+        count += 1
+        votes_by_user = room.get_all_votes()
+        votes = votes_by_user.values()
+
+        num_total_votes = len(votes)
+        num_increase = sum(1 for vote in votes if vote.name == "INCREASE")
+        num_continue = sum(1 for vote in votes if vote.name == "CONTINUE")
+        # abandon votes are novotes plus explicit abandon
+        num_abandon = num_total_votes - num_increase - num_continue
+
+        if num_increase >= num_continue and num_increase >= num_abandon:
+            if room.level in to_merge_by_level:
+                other_room = to_merge_by_level.pop(room.level)
+                merge_rooms(room, other_room)
+            else:
+                to_merge_by_level[room.level] = room
+        elif num_continue >= num_abandon:
+            continue_room(room)
+        else:
+            abandon_room(room)
+
+    for level, orphaned_room in to_merge_by_level.iteritems():
+        alert_no_match(orphaned_room)
+    print "%s: done reaping (%s rooms took %s)" % (datetime.now(g.tz), count, datetime.now(g.tz) - now)
+
+
+def continue_room(room):
+    print "continuing %s" % room
+    room.continu()
+
+    websockets.send_broadcast(
+        namespace="/robin/" + room.id,
+        type="continue",
+        payload={},
+    )
+
+
+def abandon_room(room):
+    print "abandoning %s" % room
+    room.abandon()
+
+    websockets.send_broadcast(
+        namespace="/robin/" + room.id,
+        type="abandon",
+        payload={},
+    )
+
+
+def merge_rooms(room1, room2):
+    print "merging %s + %s" % (room1, room2)
+    new_room = RobinRoom.merge(room1, room2)
+
+    for room in (room1, room2):
+        websockets.send_broadcast(
+            namespace="/robin/" + room.id,
+            type="merge",
+            payload={
+                "destination": new_room.id,
+            },
+        )
+
+
+def alert_no_match(room):
+    print "no match for %s" % room
+    room.continu()
+
+    websockets.send_broadcast(
+        namespace="/robin/" + room.id,
+        type="no_match",
+        payload={},
+    )

--- a/reddit_robin/reaper.py
+++ b/reddit_robin/reaper.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from pylons import app_globals as g
 
 from r2.lib import websockets
-from .models import RobinRoom
+from .models import RobinRoom, move_dead_rooms
 
 
 """
@@ -74,6 +74,8 @@ def reap_ripe_rooms(room_age_minutes=10):
     for level, orphaned_room in to_merge_by_level.iteritems():
         alert_no_match(orphaned_room)
     print "%s: done reaping (%s rooms took %s)" % (datetime.now(g.tz), count, datetime.now(g.tz) - now)
+
+    move_dead_rooms()
 
 
 def continue_room(room):

--- a/reddit_robin/templates/robinadmin.html
+++ b/reddit_robin/templates/robinadmin.html
@@ -1,0 +1,28 @@
+<h1>robin admin</h1>
+
+<div id="admin-robin">
+  <button class="prompt-button btn" onclick="return runPrompt(this);">
+    SEND VOTING PROMPT
+  </button>
+  <button class="reap-button btn" onclick="return runReaper(this);">
+    START REAPER
+  </button>
+</div>
+
+<script>
+function runPrompt(elem) {
+  r.ajax({
+    type: 'POST',
+    url: '/api/admin_prompt',
+  });
+  return false;
+}
+
+function runReaper(elem) {
+  r.ajax({
+    type: 'POST',
+    url: '/api/admin_reap',
+  });
+  return false;
+}
+</script>

--- a/reddit_robin/templates/robinall.html
+++ b/reddit_robin/templates/robinall.html
@@ -1,7 +1,17 @@
-<h1>robin</h1>
+<h1>robin (${len(thing.participants_by_room)} rooms)</h1>
 
 <ul>
-  %for room_name in thing.all_rooms:
-    <li>${room_name}</li>
+  %for room_id, participants in thing.participants_by_room.iteritems():
+    <li>
+      <%
+        if len(participants) > 32:
+          name_str = ', '.join(user.name for user in participants[:32])
+          name_str += ', ...'
+          name_str += ' (%s total)' % len(participants)
+        else:
+          name_str = ', '.join(user.name for user in participants)
+      %>
+      <a href="/robin/${room_id}">${room_id}</a>: ${name_str}
+    </li>
   %endfor
 </ul>

--- a/reddit_robin/templates/robinchat.html
+++ b/reddit_robin/templates/robinchat.html
@@ -1,6 +1,6 @@
 <div class="robin-chat" id="robinChat">
     <header class="robin-chat--header">
-        <h1>chat in &#32;<span class="robin-chat--room-name">${thing.room._id}</span></h1>
+        <h1>chat in &#32;<span class="robin-chat--room-name">${thing.room.name}</span></h1>
     </header>
 
     <div class="robin-chat--main">

--- a/reddit_robin/templates/robinjoin.html
+++ b/reddit_robin/templates/robinjoin.html
@@ -18,7 +18,7 @@ function joinRoom(elem) {
       if ('roomId' in res.responseJSON) {
         var roomId = res.responseJSON.roomId;
         r.log('got roomId: ' + roomId);
-        $.redirect("/robin/" + roomId);
+        $.redirect("/robin");
       } else if (--i) {
         waitForAssignment(i);
       } else {

--- a/reddit_robin/validators.py
+++ b/reddit_robin/validators.py
@@ -8,13 +8,18 @@ from .models import RobinRoom
 
 
 class VRobinRoom(Validator):
+    def __init__(self, param, allow_admin=False):
+        self.allow_admin = allow_admin
+        Validator.__init__(self, param)
+
     def run(self, id):
         try:
             room = RobinRoom._byID(id)
         except tdb_cassandra.NotFound:
             abort(404)
 
-        if not room.is_participant(c.user):
+        admin_override = self.allow_admin and c.user_is_admin
+        if not (room.is_participant(c.user) or admin_override):
             abort(403)
 
         if not room.is_alive:

--- a/upstart/reddit-job-robin_prompt_for_voting.conf
+++ b/upstart/reddit-job-robin_prompt_for_voting.conf
@@ -1,0 +1,12 @@
+description "prompt robin rooms for voting"
+
+manual
+task
+stop on reddit-stop or runlevel [016]
+
+nice 10
+
+script
+    . /etc/default/reddit
+    wrap-job paster run $REDDIT_INI -c 'from reddit_robin.reaper import prompt_for_voting; prompt_for_voting()'
+end script

--- a/upstart/reddit-job-robin_reap_ripe_rooms.conf
+++ b/upstart/reddit-job-robin_reap_ripe_rooms.conf
@@ -1,0 +1,12 @@
+description "reap ripe robin rooms"
+
+manual
+task
+stop on reddit-stop or runlevel [016]
+
+nice 10
+
+script
+    . /etc/default/reddit
+    wrap-job paster run $REDDIT_INI -c 'from reddit_robin.reaper import reap_ripe_rooms; reap_ripe_rooms()'
+end script


### PR DESCRIPTION
several not quite related changes in this pr:
- room ids are now uuids, and the display name is generated on demand from the participants' names
- the room id is not really ever shown--the main chat page now lives at /robin
- add reaper
- let admins view a specific room and view a user's room
- (for testing) let admins initiate vote prompt and reaping from /robin/admin

I redid how the column families work, so if you have an existing robin install you'll need to drop the robin column families (you can do that in `cassandra-cli`) or start a fresh VM.

:eyeglasses: @madbook @umbrae @spladug 
