### PR TITLE
Steal desktop notifications from liveupdate

### DIFF
--- a/reddit_robin/__init__.py
+++ b/reddit_robin/__init__.py
@@ -15,6 +15,7 @@ class Robin(Plugin):
 
     js = {
         "robin": LocalizedModule("robin.js",
+            "lib/page-visibility.js",
             "websocket.js",
             TemplateFileSource("robin/robinmessage.html"),
             TemplateFileSource("robin/robinroomparticipant.html"),
@@ -22,6 +23,7 @@ class Robin(Plugin):
             "models/validators.js",
             "robin/models.js",
             "robin/views.js",
+            "robin/notifications.js",
             "robin/init.js",
         ),
 

--- a/reddit_robin/public/static/css/robin.less
+++ b/reddit_robin/public/static/css/robin.less
@@ -311,6 +311,21 @@ body {
         ._vote-button-style();
     }
 
+    .robin-chat--notification-widget {
+        label {
+            display: block;
+            font-size: 12px;
+            font-weight: 300;
+            letter-spacing: 0.5px;
+            line-height: 15px;
+        }
+
+        input[type=checkbox] {
+            margin-right: 5px;
+            width: 20px;
+        }
+    }
+
     .robin-chat--user-list-widget {
         .robin-room-participant {
             margin-bottom: 5px;

--- a/reddit_robin/public/static/js/lib/page-visibility.js
+++ b/reddit_robin/public/static/js/lib/page-visibility.js
@@ -1,0 +1,32 @@
+/* page visibility api polyfill by spladug. MIT license. */
+;(function(window, document, undefined) {
+  if (document.hidden !== undefined) {
+    return;
+  }
+
+  var prefixes = ['webkit', 'o', 'ms', 'moz'];
+  for (var i = 0; i < prefixes.length; i++) {
+    var prefix = prefixes[i];
+
+    if (document[prefix + 'Hidden'] !== undefined) {
+      var event = new Event('visibilitychange');
+      document.addEventListener(prefix + 'visibilitychange', function () {
+        document.dispatchEvent(event);
+      });
+
+      Object.defineProperty(document, 'hidden', {
+        get: function () {
+          return document[prefix + 'Hidden'];
+        }
+      });
+
+      Object.defineProperty(document, 'visibilityState', {
+        get: function () {
+          return document[prefix + 'VisibilityState'];
+        }
+      });
+
+      return;
+    }
+  }
+}(this, document));

--- a/reddit_robin/public/static/js/lib/tinycon.js
+++ b/reddit_robin/public/static/js/lib/tinycon.js
@@ -1,0 +1,282 @@
+/*!
+ * Tinycon - A small library for manipulating the Favicon
+ * Tom Moor, http://tommoor.com
+ * Copyright (c) 2012 Tom Moor
+ * @license MIT Licensed
+ * @version 0.6.3
+ */
+
+(function(){
+
+	var Tinycon = {};
+	var currentFavicon = null;
+	var originalFavicon = null;
+	var faviconImage = null;
+	var canvas = null;
+	var options = {};
+	var r = window.devicePixelRatio || 1;
+	var size = 16 * r;
+	var defaults = {
+		width: 7,
+		height: 9,
+		font: 10 * r + 'px arial',
+		colour: '#ffffff',
+		background: '#F03D25',
+		fallback: true,
+		crossOrigin: true,
+		abbreviate: true
+	};
+
+	var ua = (function () {
+		var agent = navigator.userAgent.toLowerCase();
+		// New function has access to 'agent' via closure
+		return function (browser) {
+			return agent.indexOf(browser) !== -1;
+		};
+	}());
+
+	var browser = {
+		ie: ua('msie'),
+		chrome: ua('chrome'),
+		webkit: ua('chrome') || ua('safari'),
+		safari: ua('safari') && !ua('chrome'),
+		mozilla: ua('mozilla') && !ua('chrome') && !ua('safari')
+	};
+
+	// private methods
+	var getFaviconTag = function(){
+
+		var links = document.getElementsByTagName('link');
+
+		for(var i=0, len=links.length; i < len; i++) {
+			if ((links[i].getAttribute('rel') || '').match(/\bicon\b/)) {
+				return links[i];
+			}
+		}
+
+		return false;
+	};
+
+	var removeFaviconTag = function(){
+
+		var links = document.getElementsByTagName('link');
+		var head = document.getElementsByTagName('head')[0];
+
+		for(var i=0, len=links.length; i < len; i++) {
+			var exists = (typeof(links[i]) !== 'undefined');
+			if (exists && (links[i].getAttribute('rel') || '').match(/\bicon\b/)) {
+				head.removeChild(links[i]);
+			}
+		}
+	};
+
+	var getCurrentFavicon = function(){
+
+		if (!originalFavicon || !currentFavicon) {
+			var tag = getFaviconTag();
+			originalFavicon = tag ? tag.getAttribute('href') : '/favicon.ico';
+			if (!currentFavicon) {
+				currentFavicon = originalFavicon
+			}
+		}
+
+		return currentFavicon;
+	};
+
+	var getCanvas = function (){
+
+		if (!canvas) {
+			canvas = document.createElement("canvas");
+			canvas.width = size;
+			canvas.height = size;
+		}
+
+		return canvas;
+	};
+
+	var setFaviconTag = function(url){
+		removeFaviconTag();
+
+		var link = document.createElement('link');
+		link.type = 'image/x-icon';
+		link.rel = 'icon';
+		link.href = url;
+		document.getElementsByTagName('head')[0].appendChild(link);
+	};
+
+	var log = function(message){
+		if (window.console) window.console.log(message);
+	};
+
+	var drawFavicon = function(label, colour) {
+
+		// fallback to updating the browser title if unsupported
+		if (!getCanvas().getContext || browser.ie || browser.safari || options.fallback === 'force') {
+			return updateTitle(label);
+		}
+
+		var context = getCanvas().getContext("2d");
+		var colour = colour || '#000000';
+		var src = getCurrentFavicon();
+
+		faviconImage = document.createElement('img');
+		faviconImage.onload = function() {
+
+			// clear canvas
+			context.clearRect(0, 0, size, size);
+
+			// draw the favicon
+			context.drawImage(faviconImage, 0, 0, faviconImage.width, faviconImage.height, 0, 0, size, size);
+
+			// draw bubble over the top
+			if ((label + '').length > 0) drawBubble(context, label, colour);
+
+			// refresh tag in page
+			refreshFavicon();
+		};
+
+		// allow cross origin resource requests if the image is not a data:uri
+		// as detailed here: https://github.com/mrdoob/three.js/issues/1305
+		if (!src.match(/^data/) && options.crossOrigin) {
+			faviconImage.crossOrigin = 'anonymous';
+		}
+
+		faviconImage.src = src;
+	};
+
+	var updateTitle = function(label) {
+
+		if (options.fallback) {
+			// Grab the current title that we can prefix with the label
+			var originalTitle = document.title;
+
+			// Strip out the old label if there is one
+			if (originalTitle[0] === '(') {
+				originalTitle = originalTitle.slice(originalTitle.indexOf(' '));
+			}
+
+			if ((label + '').length > 0) {
+				document.title = '(' + label + ') ' + originalTitle;
+			} else {
+				document.title = originalTitle;
+			}
+		}
+	};
+
+	var drawBubble = function(context, label, colour) {
+
+		// automatic abbreviation for long (>2 digits) numbers
+		if (typeof label == 'number' && label > 99 && options.abbreviate) {
+			label = abbreviateNumber(label);
+		}
+
+		// bubble needs to be larger for double digits
+		var len = (label + '').length-1;
+
+		var width = options.width * r + (6 * r * len),
+			height = options.height * r;
+
+		var top = size - height,
+            left = size - width - r,
+            bottom = 16 * r,
+            right = 16 * r,
+            radius = 2 * r;
+
+		// webkit seems to render fonts lighter than firefox
+		context.font = (browser.webkit ? 'bold ' : '') + options.font;
+		context.fillStyle = options.background;
+		context.strokeStyle = options.background;
+		context.lineWidth = r;
+
+		// bubble
+		context.beginPath();
+        context.moveTo(left + radius, top);
+		context.quadraticCurveTo(left, top, left, top + radius);
+		context.lineTo(left, bottom - radius);
+        context.quadraticCurveTo(left, bottom, left + radius, bottom);
+        context.lineTo(right - radius, bottom);
+        context.quadraticCurveTo(right, bottom, right, bottom - radius);
+        context.lineTo(right, top + radius);
+        context.quadraticCurveTo(right, top, right - radius, top);
+        context.closePath();
+        context.fill();
+
+		// bottom shadow
+		context.beginPath();
+		context.strokeStyle = "rgba(0,0,0,0.3)";
+		context.moveTo(left + radius / 2.0, bottom);
+		context.lineTo(right - radius / 2.0, bottom);
+		context.stroke();
+
+		// label
+		context.fillStyle = options.colour;
+		context.textAlign = "right";
+		context.textBaseline = "top";
+
+		// unfortunately webkit/mozilla are a pixel different in text positioning
+		context.fillText(label, r === 2 ? 29 : 15, browser.mozilla ? 7*r : 6*r);
+	};
+
+	var refreshFavicon = function(){
+		// check support
+		if (!getCanvas().getContext) return;
+
+		setFaviconTag(getCanvas().toDataURL());
+	};
+
+	var abbreviateNumber = function(label) {
+		var metricPrefixes = [
+			['G', 1000000000],
+			['M',    1000000],
+			['k',       1000]
+		];
+
+		for(var i = 0; i < metricPrefixes.length; ++i) {
+			if (label >= metricPrefixes[i][1]) {
+				label = round(label / metricPrefixes[i][1]) + metricPrefixes[i][0];
+				break;
+			}
+		}
+
+		return label;
+	};
+
+	var round = function (value, precision) {
+		var number = new Number(value);
+		return number.toFixed(precision);
+	};
+
+	// public methods
+	Tinycon.setOptions = function(custom){
+		options = {};
+
+		for(var key in defaults){
+			options[key] = custom.hasOwnProperty(key) ? custom[key] : defaults[key];
+		}
+		return this;
+	};
+
+	Tinycon.setImage = function(url){
+		currentFavicon = url;
+		refreshFavicon();
+		return this;
+	};
+
+	Tinycon.setBubble = function(label, colour) {
+		label = label || '';
+		drawFavicon(label, colour);
+		return this;
+	};
+
+	Tinycon.reset = function(){
+		setFaviconTag(originalFavicon);
+	};
+
+	Tinycon.setOptions(defaults);
+	window.Tinycon = Tinycon;
+
+	if(typeof define === 'function' && define.amd) {
+		define(Tinycon);
+	}
+
+})();

--- a/reddit_robin/public/static/js/robin/init.js
+++ b/reddit_robin/public/static/js/robin/init.js
@@ -240,6 +240,18 @@
         this.voteWidget.setConfirmedState();
       }
 
+      // notifications
+      if ('Notification' in window) {
+        this.desktopNotifier = new r.robin.notifications.DesktopNotifier({
+          model: this.roomMessages,
+        });
+        this.desktopNotifier.render();
+        $('#robinDesktopNotifier')
+          .removeAttr('hidden')
+          .find('label')
+          .prepend(this.desktopNotifier.$el);
+      }
+
       // wire up events
       this._listenToEvents(this.room, this.roomEvents);
       this._listenToEvents(this.roomParticipants, this.roomParticipantsEvents);

--- a/reddit_robin/public/static/js/robin/models.js
+++ b/reddit_robin/public/static/js/robin/models.js
@@ -54,7 +54,8 @@
     ],
 
     defaults: {
-      'message': '',
+      message: '',
+      author: '',
     },
   });
 
@@ -113,6 +114,11 @@
 
   var RobinRoomParticipants = Backbone.Collection.extend({
     model: RobinUser,
+  });
+
+
+  var RobinRoomMessages = Backbone.Collection.extend({
+    model: RobinMessage,
   });
 
 
@@ -198,6 +204,7 @@
     RobinUser: RobinUser,
     RobinMessage: RobinMessage,
     RobinRoomParticipants: RobinRoomParticipants,
+    RobinRoomMessages: RobinRoomMessages,
     RobinVote: RobinVote,
     RobinRoom: RobinRoom,
   };

--- a/reddit_robin/public/static/js/robin/notifications.js
+++ b/reddit_robin/public/static/js/robin/notifications.js
@@ -1,0 +1,125 @@
+!function(r, Backbone, $, _, store) {
+  'use strict'
+
+  var exports = r.robin.notifications = {}
+  var NOTIFICATION_TTL_SECONDS = 10
+
+  function ellipsize(text, limit) {
+    if (text.length > limit) {
+      return text.substring(0, limit) + '…'
+    }
+    return text
+  }
+
+  exports.DesktopNotifier = Backbone.View.extend({
+    tagName: 'input',
+    
+    attributes: {
+      'type': 'checkbox',
+      'name': 'robin-desktop-notifier'
+    },
+
+    events: {
+      'change': 'onSettingsChange',
+    },
+
+    initialize: function() {
+      this.storageKey = 'robin.notifications'
+      this.requestingPermission = false
+      if (Notification.permission === 'granted') {
+        this.notificationsDesired = store.safeGet(this.storageKey)
+      } else {
+        this.notificationsDesired = false
+      }
+      this.notifications = []
+      this.listenTo(this.model, 'add', this.onNewUpdate)
+      $(document).on('visibilitychange', $.proxy(this, 'onVisibilityChange'))
+    },
+
+    shouldNotify: function() {
+      return (
+          this.notificationsDesired &&
+          Notification.permission === 'granted' &&
+          document.hidden
+      )
+    },
+
+    onNewUpdate: function(update, collection, options) {
+      // don't want to notify anyway
+      if (!this.shouldNotify()) {
+        return
+      }
+
+      var author = update.get('author');
+      var message = update.get('message');
+
+      if (author === r.config.logged) {
+        // never notify a user about their own posts
+        return
+      } else if (message.indexOf(r.config.logged) < 0) {
+        // only notify a user if the message contains their name;
+        return;
+      }
+
+      var notification = new Notification(author, {
+        body: ellipsize(message, 160),
+        icon: r.utils.staticURL('robin-icons/robin-icon-robin-big.png'),
+      })
+      this.notifications.push(notification)
+
+      notification.onclick = function(ev) {
+        window.focus()
+        ev.preventDefault()
+      }
+
+      notification.onclose = function(ev) {
+        var index = this.notifications.indexOf(ev.target)
+        this.notifications.splice(index, 1)
+      }.bind(this);
+
+      setTimeout(function() {
+        notification.close()
+      }, NOTIFICATION_TTL_SECONDS * 1000)
+    },
+
+    onVisibilityChange: function() {
+      if (!document.hidden) {
+        this.clearNotifications()
+      }
+    },
+
+    onSettingsChange: function() {
+      this.notificationsDesired = this.$el.prop('checked')
+
+      store.safeSet(this.storageKey, this.notificationsDesired)
+
+      if (this.notificationsDesired && Notification.permission !== 'granted') {
+        this.requestPermission()
+      }
+    },
+
+    requestPermission: function() {
+      this.requestingPermission = true
+
+      Notification.requestPermission(_.bind(this.onPermissionChange, this))
+
+      this.render()
+    },
+
+    onPermissionChange: function() {
+      this.requestingPermission = false
+      this.render()
+    },
+
+    clearNotifications: function() {
+      _.invoke(this.notifications, 'close')
+    },
+
+    render: function() {
+      this.$el
+        .prop('disabled', this.requestingPermission || Notification.permission === 'denied')
+        .prop('checked', this.notificationsDesired)
+      return this
+    },
+  })
+}(r, Backbone, jQuery, _, store)

--- a/reddit_robin/templates/robinchat.html
+++ b/reddit_robin/templates/robinchat.html
@@ -44,6 +44,10 @@
             </div>
         </div>
 
+        <div id="robinDesktopNotifier" class="robin-chat--sidebar-widget robin-chat--notification-widget" hidden>
+            <label>${_("Allow desktop notifications")}</label>
+        </div>
+
         <div id="robinUserList" class="robin-chat--sidebar-widget robin-chat--user-list-widget">
         </div>
     </div>


### PR DESCRIPTION
Steals the page visibility shim and tinycon from liveupdate, and adds desktop notifications for username mentions.

Everything in 8bcdce2 is copied from liveupdate, unaltered.

`notifications.js` in 4800d53 copied from liveupdate as well and _mostly_ unaltered.  Most of the updates are just replacing "liveupdate" with "robin", and some minor changes in the `onNewUpdate`.

Looks like this in the sidebar
<img width="302" alt="screen shot 2016-03-16 at 1 48 49 pm" src="https://cloud.githubusercontent.com/assets/2260961/13823052/6ffdff82-eb7e-11e5-9fad-c344390c1c3a.png">

:eyeglasses: @spladug
