### PR TITLE
reaper: Use different timers in cron based on room level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ echo 1 > robin_presence_q
 echo 1 > robin_waitinglist_q
 sudo initctl emit reddit-start
 ```
+
+Finally, enable the cron jobs:
+
+```bash
+sudo cp ~/src/robin/cron.d/* /etc/cron.d/
+```

--- a/cron.d/robin
+++ b/cron.d/robin
@@ -1,0 +1,3 @@
+* * * * * root /sbin/start reddit-job-robin_prompt_for_voting
+* * * * * root /sbin/start reddit-job-robin_reap_ripe_rooms
+

--- a/upstart/reddit-job-robin_reap_ripe_rooms.conf
+++ b/upstart/reddit-job-robin_reap_ripe_rooms.conf
@@ -8,5 +8,5 @@ nice 10
 
 script
     . /etc/default/reddit
-    wrap-job paster run $REDDIT_INI -c 'from reddit_robin.reaper import reap_ripe_rooms; reap_ripe_rooms()'
+    wrap-job paster run $REDDIT_INI -c "from reddit_robin.reaper import reap_ripe_rooms; reap_ripe_rooms()"
 end script


### PR DESCRIPTION
:eyeglasses: @spladug @madbook @bsimpson63 

See: https://reddit.slack.com/archives/infra/p1458152674000984

Concerns: Race conditions.  Should we have a lock on individual rooms so the two jobs aren't inadvertently stepping on one another?  Can we make the reaper idempotent?

Vote prompt.  Right now we send it out every 15 minutes.  If we're going to have the first room expiring after 5 minutes, we'll probably want to send the vote prompt after a few minutes.  
