### PR TITLE
Distinguish system response from notifications

### DIFF
--- a/reddit_robin/public/static/css/robin.less
+++ b/reddit_robin/public/static/css/robin.less
@@ -362,24 +362,26 @@ body {
         font-weight: 300;
     }
 
-    .robin-message--body {
+    .robin-message--message {
         margin-left: 5px;
     }
 
     &.robin-message--display-compact {
-        .robin-message--body {
+        .robin-message--message {
             margin-left: 15px;
         }
     }
 
     &.robin--user-class--system {
         color: @robin--color-text-system;
+    }
 
-        .robin-message--body {
+    &.robin--message-class--action {
+        .robin-message--from,
+        .robin-message--message {
             font-style: italic;
         }
     }
-
 }
 
 

--- a/reddit_robin/public/static/js/robin/init.js
+++ b/reddit_robin/public/static/js/robin/init.js
@@ -70,12 +70,6 @@
 
     roomEvents: {
       'success:vote': function(room, data) {
-        if (data.confirmed) {
-          this.addSystemMessage('you have confirmed your vote of ' + data.vote);
-        } else {
-          this.addSystemMessage('you have voted: ' + data.vote);
-        }
-
         this.currentUser.set(data);
       },
 
@@ -171,7 +165,7 @@
         if (messageText.length > 0) {
           this.room.postMessage('/me ' + messageText);
         } else {
-          this.addSystemMessage('use: /me yofur message here');
+          this.addSystemMessage('use: /me your message here');
         }
       },
     },

--- a/reddit_robin/public/static/js/robin/init.js
+++ b/reddit_robin/public/static/js/robin/init.js
@@ -37,11 +37,11 @@
       },
 
       'message:join': function(message) {
-        this.addSystemAction(message.user + ' has joined the room');
+        this.addUserAction(message.user, 'joined the room');
       },
 
       'message:part': function(message) {
-        this.addSystemAction(message.user + ' has left the room');
+        this.addUserAction(message.user, 'left the room');
       },
 
       'message:please_vote': function(message) {
@@ -362,9 +362,9 @@
       var user = this._ensureUser(userName, setAttrs);
 
       if (confirmed) {
-        this.addSystemAction(userName + ' confirmed their vote to ' + vote);
+        this.addUserAction(userName, 'confirmed their vote to ' + vote);
       } else {
-        this.addSystemAction(userName + ' voted to ' + vote);
+        this.addUserAction(userName, 'voted to ' + vote);
       }
     },
   });

--- a/reddit_robin/public/static/js/robin/models.js
+++ b/reddit_robin/public/static/js/robin/models.js
@@ -7,6 +7,9 @@
   var DEFAULT_USER_CLASS = 'user';
   var USER_CLASSES = ['user', 'self', 'system'];
 
+  var DEFAULT_MESSAGE_CLASS = 'message';
+  var MESSAGE_CLASSES = ['message', 'action'];
+
   function OneOf(attrName, values) {
     return function(model) {
       var value = model.get(attrName);
@@ -51,11 +54,15 @@
 
     validators: [
       r.models.validators.StringLength('message', 1, this.MAX_LENGTH),
+      OneOf('messageClass', MESSAGE_CLASSES),
+      OneOf('userClass', USER_CLASSES),
     ],
 
     defaults: {
-      message: '',
       author: '',
+      message: '',
+      messageClass: DEFAULT_MESSAGE_CLASS,
+      userClass: DEFAULT_USER_CLASS,
     },
   });
 

--- a/reddit_robin/public/static/js/robin/robinmessage.html
+++ b/reddit_robin/public/static/js/robin/robinmessage.html
@@ -2,10 +2,11 @@
         <% if (thing.displayCompact) { %>
             robin-message--display-compact
         <% } %>
+        robin--message-class--<%- thing.messageClass %>
         robin--user-class--<%- thing.userClass %>">
     <time class="robin-message--timestamp" datetime="<%- thing.isoDate %>"><%- thing.timestamp %></time>
     <% if (!thing.displayCompact) { %>
-      <span class="robin-message--from robin--username"><%- thing.from %></span>
+      <span class="robin-message--from robin--username"><%- thing.author %></span>
     <% } %>
-    <span class="robin-message--body"><%- thing.body %></span>
+    <span class="robin-message--message"><%- thing.message %></span>
 </div>

--- a/reddit_robin/public/static/js/robin/views.js
+++ b/reddit_robin/public/static/js/robin/views.js
@@ -9,23 +9,23 @@
       this.lastMessageFrom = null;
     },
 
-    addMessage: function(user, message) {
+    addMessage: function(message) {
       var date = new Date();
       var time = date.toLocaleTimeString ? date.toLocaleTimeString() : date.toTimeString();      
       var scrollOffset = (this.$el.prop('scrollHeight') - this.$el.scrollTop());
       var wasScrolledDown = (scrollOffset === this.$el.height());
-      var templateData = {
+
+      var templateData = _.extend(message.toJSON(), {
         isoDate: date.toISOString(),
         timestamp: time,
-        from: user.get('name'),
-        userClass: user.get('userClass'),
-        body: message.get('message'),
-      };
+      });
 
-      if (user.get('name') === this.lastMessageFrom) {
+      if (message.get('messageClass') !== 'message') {
+        this.lastMessageFrom = null;
+      } else if (message.get('author') === this.lastMessageFrom) {
         templateData.displayCompact = true;
       } else {
-        this.lastMessageFrom = user.get('name');
+        this.lastMessageFrom = message.get('author');
       }
 
       var el = r.templates.make(this.TEMPLATE_NAME, templateData);


### PR DESCRIPTION
I separated the styling of normal messages from "actions", which are displayed in _italics_ and always include the username (i.e. they don't "compact").  Unprompted system updates use this formatting, while responses to chat commands and some other updates will use the normal message formatting (which is still grey for visual distinction from other users' messages).

Additionally, I added the `/me` chat command so users can create their own "action" text.

Finally, I moved some updates that were from the system to "action" messages from the user, including joining, parting, and voting.  Because these are formatted the same way as messages created via the `/me` command by the user, it brings up the possibility for users to troll with messages like `/me voted to INCREASE` or `/me left the room`.  I think that's :+1: 

Also (I guess _actually_ finally) I removed the redundant vote message you see when _you_ vote.

<img width="529" alt="screen shot 2016-03-18 at 11 54 03 am" src="https://cloud.githubusercontent.com/assets/2260961/13883513/28adeca4-ed00-11e5-979c-22cf3fdef468.png">

:eyeglasses: @umbrae 
