### PR TITLE
Add ratelimits to messaging and voting

### DIFF
--- a/reddit_robin/__init__.py
+++ b/reddit_robin/__init__.py
@@ -34,18 +34,14 @@ class Robin(Plugin):
         ),
     }
 
-    config = {
-        # TODO: your static configuratation options go here, e.g.:
-        # ConfigValue.int: [
-        #     "robin_blargs",
-        # ],
-    }
-
     live_config = {
-        # TODO: your live configuratation options go here, e.g.:
-        # ConfigValue.int: [
-        #     "robin_realtime_blargs",
-        # ],
+        ConfigValue.int: [
+            "robin_ratelimit_window",
+        ],
+
+        ConfigValue.dict(ConfigValue.int, ConfigValue.float): [
+            "robin_ratelimit_avg_per_sec",
+        ],
     }
 
     def declare_queues(self, queues):


### PR DESCRIPTION
These use the ratelimit library so they allow for burstiness. We have to
live configurables: the length of the burst window (in seconds) and the
number of events per second we'll allow through on average during that
window.

This does not add any frontend display of a ratelimit response, but does
pass back information which could be used to do so (i.e. how much time
until the ratelimit resets).

:eyeglasses: @umbrae @madbook 
