### PR TITLE
Add option to disable new rooms for heavy load.

### DIFF
--- a/reddit_robin/public/static/css/robin.less
+++ b/reddit_robin/public/static/css/robin.less
@@ -218,6 +218,16 @@ body {
         }
     }
 
+    .robin-home--heavy-load-container {
+        padding: 10px;
+        margin: 10px;
+        background-color: #FFFC7F;
+        font-size: 1.2em;
+        -webkit-border-radius: 5px;
+        -moz-border-radius: 5px;
+        border-radius: 5px;
+    }
+
 }
 
 .footer-parent {

--- a/reddit_robin/templates/robinjoin.html
+++ b/reddit_robin/templates/robinjoin.html
@@ -1,12 +1,19 @@
 <% from r2.lib import js %>
 
 <div class="robin-home">
-    <div id="joinRobinContainer"
-            class="robin-home--thebutton-container robin--thebutton-state--locked">
-        <button class="robin-home--thebutton" id="joinRobin">
-            <span class="robin-home--thebutton-text">Participate</span>
-        </button>
-    </div>
+    % if thing.robin_heavy_load: 
+        <div id="heavyLoadRobinContainer"
+                class="robin-home--heavy-load-container">
+            Robin is currently experiencing heavy load.  Please try again later.
+        </div>
+    % else:
+        <div id="joinRobinContainer"
+                class="robin-home--thebutton-container robin--thebutton-state--locked">
+            <button class="robin-home--thebutton" id="joinRobin">
+                <span class="robin-home--thebutton-text">Participate</span>
+            </button>
+        </div>
+    % endif 
 </div>
 
 ${unsafe(js.use("robin-join"))}


### PR DESCRIPTION
:eyeglasses: @bsimpson63 @madbook 

I thought more about this, and I don't think just disabling the cron and letting the queue back up is the best solution.  This will cut off the new rooms at the source (POST request) and display a message to the user, so they actually know why things aren't working.  It makes it look a bit better rather than things just breaking without showing the user anything.

Matt, feel free to make the appearance of the box look better.  I think it's _okay_ right now, but a more elegant one might be nice.
