### PR TITLE
Update presence on websocket messages

### DIFF
--- a/reddit_robin/public/static/js/robin/init.js
+++ b/reddit_robin/public/static/js/robin/init.js
@@ -43,11 +43,11 @@
       },
 
       'message:join': function(message) {
-        this.addUserAction(message.user, 'joined the room');
+        this._ensureUser(message.user, { present: true });
       },
 
       'message:part': function(message) {
-        this.addUserAction(message.user, 'left the room');
+        this._ensureUser(message.user, { present: false });
       },
 
       'message:please_vote': function(message) {


### PR DESCRIPTION
This does the sidebar presence updates on join/part messages and removes the system message for the same events.

(i tried this earlier and didn't check it. i have checked it now. it works.)

:eyeglasses: @madbook 
