### PR TITLE
Update vote labels

### DIFF
--- a/reddit_robin/public/static/js/robin/init.js
+++ b/reddit_robin/public/static/js/robin/init.js
@@ -186,17 +186,36 @@
         this.addSystemMessage('"/' + command + '" is not a command');
       },
 
-      'vote': function(vote) {
+      'vote': function(voteLabel) {
         if (this.room.isComplete()) {
           this.addSystemMessage('voting is complete');
-        } else if (!vote) {
-          this.addSystemMessage('use: /vote [' + r.robin.VOTE_TYPES.join(',') + ']');
-        } else if (r.robin.VOTE_TYPES.indexOf(vote.toUpperCase()) < 0) {
+          return;
+        }
+
+        var voteLabels = r.robin.VOTE_TYPES.map(function(vote) {
+          return this.getLabelFromVote(vote);
+        }, this);
+        
+        if (!voteLabel) {
+          this.addSystemMessage('use: /vote [' + voteLabels.join(',') + ']');
+          return;
+        }
+
+        var voteLabelUpper = voteLabel.toUpperCase();
+
+        if (voteLabels.indexOf(voteLabelUpper) < 0) {
+          // support passing in the actual vote values
+          voteLabelUpper = this.getLabelFromVote(voteLabelUpper);
+        }
+
+        var vote = this.getVoteFromLabel(voteLabelUpper);
+
+        if (r.robin.VOTE_TYPES.indexOf(vote) < 0) {
           this.addSystemMessage('that is not a valid vote type');
-        } else if (vote.toUpperCase() === this.currentUser.get('vote')) {
+        } else if (vote === this.currentUser.get('vote')) {
           this.addSystemMessage('that is already your vote');
         } else {
-          this.room.postVote(vote.toUpperCase());
+          this.room.postVote(vote);
           this.voteWidget.setActiveVote(vote);
         }
       },
@@ -308,6 +327,17 @@
         model: this.roomMessages,
       });
 
+      // vote label mapping
+      this._voteToLabel = {};
+      this._labelToVote = {};
+      this.voteWidget.$el.find('.' + this.voteWidget.VOTE_BUTTON_CLASS).toArray().forEach(function(el) {
+        var $el = $(el);
+        var vote = $el.val().toUpperCase();
+        var label = $el.find('.' + this.voteWidget.VOTE_LABEL_CLASS).text().toUpperCase();
+        this._voteToLabel[vote] = label;
+        this._labelToVote[label] = vote;
+      }, this);
+
       // wire up events
       this._listenToEvents(this.room, this.roomEvents);
       this._listenToEvents(this.roomParticipants, this.roomParticipantsEvents);
@@ -320,6 +350,14 @@
       this.websocket = new r.WebSocket(options.websocket_url);
       this.websocket.on(this.websocketEvents);
       this.websocket.start();
+    },
+
+    getLabelFromVote: function(vote) {
+      return this._voteToLabel[vote];
+    },
+
+    getVoteFromLabel: function(label) {
+      return this._labelToVote[label];
     },
 
     _listenToEvents: function(other, eventMap) {
@@ -405,8 +443,9 @@
         present: true,
       };
       var user = this._ensureUser(userName, setAttrs);
+      var voteLabel = this.getLabelFromVote(vote) || vote;
 
-      this.addUserAction(userName, 'voted to ' + vote);
+      this.addUserAction(userName, 'voted to ' + voteLabel);
     },
   });
 

--- a/reddit_robin/public/static/js/robin/views.js
+++ b/reddit_robin/public/static/js/robin/views.js
@@ -123,18 +123,20 @@
 
   var RobinVoteWidget = RobinButtonWidget.extend({
     VOTE_BUTTON_CLASS: 'robin-chat--vote',
+    VOTE_LABEL_CLASS: 'robin-chat--vote-label',
 
     events: {
       'click .robin-chat--vote': '_onVote',
     },
 
     _onVote: function(e) {
+      var target = $(e.target).closest('button')[0];
       if (this.isHidden) { return; }
-      if (e.target === this.currentTarget) { return; }
+      if (target === this.currentTarget) { return; }
 
-      var value = e.target.value;
+      var value = target.value;
       this.trigger('vote', value);
-      this._setActiveTarget(e.target);
+      this._setActiveTarget(target);
     },
 
     setActiveVote: function(voteType) {

--- a/reddit_robin/templates/robinchat.html
+++ b/reddit_robin/templates/robinchat.html
@@ -29,15 +29,15 @@
             <div class="robin-chat--buttons">
                 <button class="robin-chat--vote robin-chat--vote-abandon"
                         value="ABANDON">
-                    abandon
+                    <span class="robin-chat--vote-label">abandon</span>
                 </button>
                 <button class="robin-chat--vote robin-chat--vote-continue"
                         value="CONTINUE">
-                    continue
+                    <span class="robin-chat--vote-label">stay</span>
                 </button>
                 <button class="robin-chat--vote robin-chat--vote-increase"
                         value="INCREASE">
-                    increase
+                    <span class="robin-chat--vote-label">grow</span>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
> Keeps the existing values for votes, but uses the labels from the vote
> widget for vote notifications and chat commands.

Has a _little_ bit of overlap with #48, but that one was all pretty much style changes so I broke it out.  System messages and chat commands will both use whatever labels are in the UI, so in theory this should do the right thing if we marked up the ui strings for translation (though with the short timeframe that's probably not necessary).

Again, not `eyeglasses`-ing yet because I don't want to ping anyone too late
