### PR TITLE
Add simple mobile styling

### DIFF
--- a/reddit_robin/public/static/css/robin.less
+++ b/reddit_robin/public/static/css/robin.less
@@ -263,6 +263,7 @@ body {
 
     .robin-chat--main {
         flex: 1 1;
+        border: 1px solid transparent; // I have no idea why but this seems to fix the flex in safari
     }
 
     .robin-chat--window {

--- a/reddit_robin/public/static/css/robin.less
+++ b/reddit_robin/public/static/css/robin.less
@@ -13,6 +13,9 @@
 @color-press-5: #0083C7;
 @color-press-6: #820080;
 
+// borrowed from variables.less
+@screen-sm-min: 768px;
+
 body {
     background-color: @color-pale-grey;
 }
@@ -617,4 +620,30 @@ body {
 
 ._robin-icon-voted-increase-away_2x() {
     background-image: url('../robin-icons/robin-icon-voted-increase-away_2x.png'); /* SPRITE pixel-ratio=2 */
+}
+
+
+@media all and (max-width: @screen-sm-min) {
+  .robin-chat--window {
+    max-height: 200px;
+  }
+
+  .robin-chat--buttons {
+    text-align: center;
+  }
+
+  .robin-chat--vote {
+    display: inline-block !important;
+  }
+
+  ////////// hacks to clean up the header and footer until the rest of reddit is responsive
+  #sr-header-area,
+  #header-bottom-right {
+      display: none;
+  }
+
+  .footer {
+      display:none;
+  }
+  //////////
 }

--- a/reddit_robin/templates/robinchatpage.html
+++ b/reddit_robin/templates/robinchatpage.html
@@ -1,5 +1,10 @@
 <%inherit file="reddit.html"/>
 
+<%def name="pagemeta()">
+  ${parent.pagemeta()}
+  <meta name="viewport" content="width=device-width">
+</%def>
+
 <%def name="javascript_bottom()">
     <% from r2.lib import js %>
     ${parent.javascript_bottom()}


### PR DESCRIPTION
No eyeglass until the morning. This is for @madbook though!

Just a couple small updates:
1. Safari was busted before. I have no idea why but adding a transparent border fixed the flow for everything. This included mobile and desktop.
2. I added some simple mobile styling just so it isn't fully unusable on mobile. I stole a lot of this from how reddit live does it. With the vote patch applies, it now looks like:

![image](https://cloud.githubusercontent.com/assets/285920/14137062/e4fc1e26-f61a-11e5-8a6f-dd76202c1578.png)

Scrolled down:

![image](https://cloud.githubusercontent.com/assets/285920/14137070/f0157596-f61a-11e5-9d35-ee89be2ccb35.png)

(Ignore the connect errors, that's just dev stuff with safari)
