### PR TITLE
Add basic reminder chat command

### DIFF
--- a/reddit_robin/public/static/js/robin/init.js
+++ b/reddit_robin/public/static/js/robin/init.js
@@ -214,6 +214,25 @@
       'leave_room': function() {
         this.room.postLeaveRoom();
       },
+
+      'remind': function(time /* ,args */) {
+        time = parseInt(time, 10);
+        var timerMessage = [].slice.call(arguments, 1).join(' ');
+
+        if (_.isNaN(time) || timerMessage.length === 0) {
+          this.addSystemMessage('use: /remind <seconds> <message>');
+          return;
+        }
+
+        var userName = this.currentUser.get('name');
+        var messageText = userName + ': ' + timerMessage;
+
+        setTimeout(function() {
+          this.addSystemMessage(messageText.slice(0, models.RobinMessage.MAX_LENGTH));
+        }.bind(this), time * 1000);
+
+        this.addSystemAction('set timer for ' + time + ' seconds from now');
+      },
     },
 
     initialize: function(options) {


### PR DESCRIPTION
Not on the todo list, but really quick and easy.  It doesn't track reminders across page reloads or anything, but it _will_ give you a desktop notification if you have that enabled.
