### PR TITLE
Remove TTL from presence

### DIFF
--- a/reddit_robin/models.py
+++ b/reddit_robin/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 import math
 
 from pylons import app_globals as g

--- a/reddit_robin/models.py
+++ b/reddit_robin/models.py
@@ -285,8 +285,6 @@ class ParticipantPresenceByRoom(tdb_cassandra.View):
     _read_consistency_level = tdb_cassandra.CL.QUORUM
     _write_consistency_level = tdb_cassandra.CL.QUORUM
 
-    _ttl = timedelta(minutes=2)
-
     @classmethod
     def _rowkey(cls, room):
         return room._id


### PR DESCRIPTION
Because we're edge-triggered, the presence markers falling away after
two minutes results in incorrect presence display when intially loading
a room. We'll just rely on the edge triggered messages being accurate
and the frontend doing visual fixups automatically on message to get
away with this.

:eyeglasses: @bsimpson63 
