### PR TITLE
Style nits

### DIFF
--- a/reddit_robin/public/static/css/robin.less
+++ b/reddit_robin/public/static/css/robin.less
@@ -303,7 +303,9 @@ body {
     }
 
     .robin-chat--main {
-        .flex(1 1 auto);
+        .flex(1 1);
+        // fixes flex layout in Safari :(
+        border-right: 1px solid transparent;
     }
 
     .robin-chat--window {
@@ -454,6 +456,7 @@ body {
     font-size: 14px;
     line-height: 15px;
     padding: 2px 5px 3px;
+    word-break: break-all;
 
     .robin-message--from {
         transition: opacity 300ms ease 0.5s;

--- a/reddit_robin/public/static/css/robin.less
+++ b/reddit_robin/public/static/css/robin.less
@@ -712,6 +712,11 @@ only screen and (-webkit-min-device-pixel-ratio: 2) {
 
 
 @media all and (max-width: @screen-sm-min) {
+  // abandon flex
+  .robin-chat {
+    display: block;
+  }
+
   .robin-chat--window {
     max-height: 200px;
   }

--- a/reddit_robin/public/static/css/robin.less
+++ b/reddit_robin/public/static/css/robin.less
@@ -65,8 +65,8 @@ body {
 @robin--color-text-inverted: @color-pale-grey;
 @robin--color-text-system: @color-grey;
 @robin--color-flair-0: @color-press-1;
-@robin--color-flair-1: @color-press-2;
-@robin--color-flair-2: @color-press-3;
+@robin--color-flair-1: darken(@color-press-2, 2%);
+@robin--color-flair-2: darken(@color-press-3, 5%);
 @robin--color-flair-3: @color-press-4;
 @robin--color-flair-4: @color-press-5;
 @robin--color-flair-5: @color-press-6;


### PR DESCRIPTION
:eyeglasses: @umbrae 

Very slight adjustment to the yellow, want to keep them as close as possible to the original flair colors.  Tweaked the orange a bit to help keep it distinct.  Not sure if this is quite enough.
<img width="145" alt="screen shot 2016-03-30 at 5 54 05 pm" src="https://cloud.githubusercontent.com/assets/2260961/14159459/f8697e8e-f6a3-11e5-8a4a-dd020d2ebea8.png"><img width="150" alt="screen shot 2016-03-30 at 5 53 46 pm" src="https://cloud.githubusercontent.com/assets/2260961/14159458/f867ccd8-f6a3-11e5-8db0-7d5f0961d14e.png">
<sup>Before (left), After (right)</sup>

I had to bring back your flex fix for Safari from #50.  The `auto` value for `flex` was fixing it in most cases, but preventing the fix for the long line issue from working.  Damn Safari and its quirks.

I also made a small change to the mobile layout styles, so that the sidebar will take up the full width.
