### PR TITLE
Broadcast when users leave room in continue state

### DIFF
--- a/reddit_robin/controllers.py
+++ b/reddit_robin/controllers.py
@@ -280,6 +280,13 @@ class RobinController(RedditController):
         if not room:
             return
         room.remove_participants([c.user])
+        websockets.send_broadcast(
+            namespace="/robin/" + room.id,
+            type="users_abandoned",
+            payload={
+                "users": [c.user.name],
+            },
+        )
 
     @json_validate(
         VUser(),


### PR DESCRIPTION
Uses the same event that the reaper does when culling abandoners from rooms, and the frontend already handles that by posting a message and removing those users from the sidebar.

:eyeglasses: @bsimpson63 
