### PR TITLE
ratelimits: Fix parsing of live config

### DIFF
--- a/reddit_robin/controllers.py
+++ b/reddit_robin/controllers.py
@@ -159,8 +159,8 @@ class RobinController(RedditController):
         # for 2.
         desired_avg_per_sec = 1
         by_level = g.live_config.get("robin_ratelimit_avg_per_sec", {})
-        for level, avg_per_sec in sorted(by_level.items(), key=lambda (x,y): x):
-            if level > room.level:
+        for level, avg_per_sec in sorted(by_level.items(), key=lambda (x,y): int(x)):
+            if int(level) > room.level:
                 break
             desired_avg_per_sec = avg_per_sec
 


### PR DESCRIPTION
When going through ZooKeeper (for actually live live config), the data
transits JSON serde. JSON requires that dict keys are strings, so
this integer key nonsense doesn't work once it's gone through the JSON
transform and back. We'll hack around this by just intifying when we use
it.

:eyeglasses: @bsimpson63 @madbook 
