### PR TITLE
Show ellipsis for long room names

### DIFF
--- a/reddit_robin/public/static/css/robin.less
+++ b/reddit_robin/public/static/css/robin.less
@@ -280,26 +280,29 @@ body {
     @robin-chat--color-vote-active: @color-grey;
     @robin-chat--color-vote-down: darken(@color-grey, 5%);
 
-    // TODO import all of the less mixins for flexbox rendering
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    .display-flex();
-    .flex-direction(row);
-    .flex-wrap(wrap);
 
     .robin-chat--header {
         border-bottom: 1px solid darken(@color-pale-grey, 5%);
         box-sizing: border-box;
-        .flex(1 0 100%);
         padding: 15px 20px;
         
         h1 {
             line-height: 20px;
             margin: 0;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
     }
 
     .robin-chat--room-name {
         color: @robin-chat--color-title;
+    }
+
+    .robin-chat--body {
+        .display-flex();
+        .flex-direction(row);
     }
 
     .robin-chat--main {
@@ -719,7 +722,7 @@ only screen and (-webkit-min-device-pixel-ratio: 2) {
 
 @media all and (max-width: @screen-sm-min) {
   // abandon flex
-  .robin-chat {
+  .robin-chat .robin-chat--body {
     display: block;
   }
 

--- a/reddit_robin/templates/robinchat.html
+++ b/reddit_robin/templates/robinchat.html
@@ -3,74 +3,76 @@
 %>
 <div class="robin-chat" id="robinChat">
     <header class="robin-chat--header">
-        <h1>chat in &#32;<span class="robin-chat--room-name">${thing.room.name}</span></h1>
+        <h1>chat in &#32;<span class="robin-chat--room-name">${thing.room.name * 100}</span></h1>
     </header>
 
-    <div class="robin-chat--main">
-        <div id="robinChatWindow" class="robin-chat--window">
-            <div id="robinChatMessageList" class="robin-chat--message-list"></div>
+    <div class="robin-chat--body">
+        <div class="robin-chat--main">
+            <div id="robinChatWindow" class="robin-chat--window">
+                <div id="robinChatMessageList" class="robin-chat--message-list"></div>
+            </div>
+
+            <div id="robinChatInput" class="robin-chat--input">
+                <form id="robinSendMessage" action="/api/robin/${thing.room._id}/message" method="POST">
+                    <div class="text-counter">
+                        <span class="text-counter-display"></span>&#32;
+                        ${_("remaining")}
+                    </div>
+                    <input type="text"
+                            class="c-form-control text-counter-input"
+                            name="message"
+                            autocomplete="off"
+                            maxlength="140"
+                            required>
+                    <input type="submit" value="send">
+                    <span class="status error" style="display:none"></span>
+                </form>
+            </div>
         </div>
 
-        <div id="robinChatInput" class="robin-chat--input">
-            <form id="robinSendMessage" action="/api/robin/${thing.room._id}/message" method="POST">
-                <div class="text-counter">
-                    <span class="text-counter-display"></span>&#32;
-                    ${_("remaining")}
+        <div class="robin-chat--sidebar">
+            <div id="robinVoteWidget" class="robin-chat--sidebar-widget robin-chat--vote-widget" hidden>
+                <div class="robin-chat--buttons">
+                    <button class="robin-chat--vote robin-chat--vote-abandon robin--vote-class--abandon"
+                            value="ABANDON">
+                        <span class="robin--icon"></span>
+                        <span class="robin-chat--vote-label">abandon</span>
+                    </button>
+                    <button class="robin-chat--vote robin-chat--vote-continue robin--vote-class--continue"
+                            value="CONTINUE">
+                        <span class="robin--icon"></span>
+                        <span class="robin-chat--vote-label">stay</span>
+                    </button>
+                    <button class="robin-chat--vote robin-chat--vote-increase robin--vote-class--increase"
+                            value="INCREASE">
+                        <span class="robin--icon"></span>
+                        <span class="robin-chat--vote-label">grow</span>
+                    </button>
                 </div>
-                <input type="text"
-                        class="c-form-control text-counter-input"
-                        name="message"
-                        autocomplete="off"
-                        maxlength="140"
-                        required>
-                <input type="submit" value="send">
-                <span class="status error" style="display:none"></span>
-            </form>
-        </div>
-    </div>
-
-    <div class="robin-chat--sidebar">
-        <div id="robinVoteWidget" class="robin-chat--sidebar-widget robin-chat--vote-widget" hidden>
-            <div class="robin-chat--buttons">
-                <button class="robin-chat--vote robin-chat--vote-abandon robin--vote-class--abandon"
-                        value="ABANDON">
-                    <span class="robin--icon"></span>
-                    <span class="robin-chat--vote-label">abandon</span>
-                </button>
-                <button class="robin-chat--vote robin-chat--vote-continue robin--vote-class--continue"
-                        value="CONTINUE">
-                    <span class="robin--icon"></span>
-                    <span class="robin-chat--vote-label">stay</span>
-                </button>
-                <button class="robin-chat--vote robin-chat--vote-increase robin--vote-class--increase"
-                        value="INCREASE">
-                    <span class="robin--icon"></span>
-                    <span class="robin-chat--vote-label">grow</span>
-                </button>
             </div>
-        </div>
 
-        <div id="robinQuitWidget" class="robin-chat--sidebar-widget robin-chat--quit-widget" hidden>
-            <div class="robin-chat--buttons">
-                <button class="robin-chat--quit">
-                    leave room
-                </button>
+            <div id="robinQuitWidget" class="robin-chat--sidebar-widget robin-chat--quit-widget" hidden>
+                <div class="robin-chat--buttons">
+                    <button class="robin-chat--quit">
+                        leave room
+                    </button>
+                </div>
             </div>
-        </div>
 
-        <div id="robinDesktopNotifier" class="robin-chat--sidebar-widget robin-chat--notification-widget" hidden>
-            <label>${_("Allow desktop notifications")}</label>
-        </div>
+            <div id="robinDesktopNotifier" class="robin-chat--sidebar-widget robin-chat--notification-widget" hidden>
+                <label>${_("Allow desktop notifications")}</label>
+            </div>
 
-        <div id="robinUserList" class="robin-chat--sidebar-widget robin-chat--user-list-widget">
-        </div>
+            <div id="robinUserList" class="robin-chat--sidebar-widget robin-chat--user-list-widget">
+            </div>
 
-        <div class="robin-chat--sidebar-widget robin-chat--report">
-            <%
-              encoded_subject = quote("[robin #%s] Rule Violation - (enter subject)" % thing.room.name)
-              encoded_message = quote("(please describe your issue here)\n\n---\n\nRoom ID: %s" % thing.room._id)
-            %>
-            <a href="/message/compose?to=%2Fr%2Freddit.com&amp;subject=${encoded_subject}&amp;message=${encoded_message}" target="_blank">${_("report a rule violation")}</a>
+            <div class="robin-chat--sidebar-widget robin-chat--report">
+                <%
+                  encoded_subject = quote("[robin #%s] Rule Violation - (enter subject)" % thing.room.name)
+                  encoded_message = quote("(please describe your issue here)\n\n---\n\nRoom ID: %s" % thing.room._id)
+                %>
+                <a href="/message/compose?to=%2Fr%2Freddit.com&amp;subject=${encoded_subject}&amp;message=${encoded_message}" target="_blank">${_("report a rule violation")}</a>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
> This doesn't work when the header is in the flexbox layout, but it doesn't
> really need to be.

Most of the diff is whitespace from changing indentation, so appending `?w=1` to the url will make it more readable

:eyeglasses: @dellis23 
