### PR TITLE
Add a little wiggle room to the autoscroller

### DIFF
--- a/reddit_robin/public/static/js/robin/views.js
+++ b/reddit_robin/public/static/js/robin/views.js
@@ -20,7 +20,8 @@
       var date = new Date();
       var time = date.toLocaleTimeString ? date.toLocaleTimeString() : date.toTimeString();      
       var scrollOffset = (this.$el.prop('scrollHeight') - this.$el.scrollTop());
-      var wasScrolledDown = (scrollOffset === this.$el.height());
+      var scrollDelta = scrollOffset - this.$el.height();
+      var wasScrolledDown = (Math.abs(scrollDelta) < 5);
 
       var templateData = _.extend(message.toJSON(), {
         isoDate: date.toISOString(),


### PR DESCRIPTION
:eyeglasses: @spladug 

The css change for the sidebar fix was somehow causing `scrollOffset` and `this.$el.height()` to be off by 1 when manually scrolling to the bottom, breaking the autoscroller. This gives it a little wiggle room so it shouldn't break again :)
