### PR TITLE
Show the correct ratelimit message

### DIFF
--- a/reddit_robin/public/static/js/robin/init.js
+++ b/reddit_robin/public/static/js/robin/init.js
@@ -108,7 +108,7 @@
 
       'invalid:message error:message': function(room, errors) {
         try {
-          this.addSystemMessage(errors[0].message);
+          this.addSystemMessage(errors[0].displayMessage);
         } catch (err) {
           this.addSystemMessage('could not send your message');
         }


### PR DESCRIPTION
I tested this, but I guess it didn't register that it was showing the version of the error message with the error name in it.  i.e  `RATELIMIT | you are doing that too much. try again in 999 milliseconds.`.  The `displayMessage` attribute has just the message without the `RATELIMIT` prefix.
