### PR TITLE
Juicy poppin transition: Add multiplier for large rooms to avoid thundering herd

### DIFF
--- a/reddit_robin/public/static/js/robin/init.js
+++ b/reddit_robin/public/static/js/robin/init.js
@@ -459,7 +459,13 @@
     },
 
     transitionRefresh: function() {
-      var timeout = 1000 + Math.floor(Math.random() * 4000);
+      var timeoutMult = 1;
+      if (this.roomParticipants.length > 1000) {
+        timeoutMult = 3;
+      } else if (this.roomParticipants.length > 100) {
+        timeoutMult = 2;
+      }
+      var timeout = 1000 + (Math.floor(Math.random() * 4000) * timeoutMult);
       this.chatWindow.startJuicyPoppin();
       setTimeout(function() {
         $.refresh();


### PR DESCRIPTION
:eyeglasses: @madbook 

For rooms with > 1000 participants, this makes it so worst case they'll have a 13 second delay. Average case they'll have a 7 second delay, which isn't so horrible with the juicy poppin, but is still maybe quite a lot. Am I being too aggressive maybe? 1000 participant rooms are fairly rare, but I also don't want to make them manually refresh.
