### PR TITLE
RobinRoom: store the room name

### DIFF
--- a/reddit_robin/matchmaker.py
+++ b/reddit_robin/matchmaker.py
@@ -50,6 +50,7 @@ def run_waitinglist():
 
             if current_room_id:
                 g.cache.delete("current_robin_room")
+                current_room.persist_computed_name()
                 websockets.send_broadcast(
                     namespace="/robin/" + current_room.id,
                     type="updated_name",


### PR DESCRIPTION
Once the room has all its participants we can store the room name
rather than looking up all the participant Accounts to calculate
the room name.

:eyeglasses: @rram @spladug 
